### PR TITLE
Make scan timeout configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,8 @@ type WPAConn interface {
 
 // Client represents a wireless client
 type Client struct {
-	conn WPAConn
+	conn        WPAConn
+	ScanTimeout time.Duration
 }
 
 // NewClient will create a new client by connecting to the
@@ -67,6 +68,12 @@ func (cl *Client) Status() (State, error) {
 
 // Scan will scan for networks and return the APs it finds
 func (cl *Client) Scan() (nets APs, err error) {
+	timeout := cl.ScanTimeout
+
+	if timeout == 0 {
+		timeout = 2 * time.Second
+	}
+
 	err = cl.conn.SendCommandBool(CmdScan)
 	if err != nil {
 		return
@@ -83,7 +90,7 @@ func (cl *Client) Scan() (nets APs, err error) {
 				return
 			case <-results.Next():
 				return
-			case <-time.NewTimer(time.Second * 2).C:
+			case <-time.NewTimer(cl.ScanTimeout).C:
 				return
 			}
 		}


### PR DESCRIPTION
Hey! We're using this library on an arm device. We faced the issue that on many scan runs, we did not receive any networks due to the scan method running into the fixed timeout of 2s because our network device needs more time to return the scan results. This PR makes the scan timeout configurable with the recently fixed value of 2s as default.